### PR TITLE
switch to microseconds async Clock

### DIFF
--- a/src/main/java/com/alvazan/orm/impl/bindings/BootstrapImpl.java
+++ b/src/main/java/com/alvazan/orm/impl/bindings/BootstrapImpl.java
@@ -16,6 +16,7 @@ import com.google.inject.name.Names;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.AstyanaxContext.Builder;
 import com.netflix.astyanax.connectionpool.NodeDiscoveryType;
+import com.netflix.astyanax.clock.MicrosecondsAsyncClock;
 import com.netflix.astyanax.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.astyanax.connectionpool.impl.ConnectionPoolType;
 import com.netflix.astyanax.connectionpool.impl.CountingConnectionPoolMonitor;
@@ -76,6 +77,7 @@ public class BootstrapImpl extends Bootstrap {
 	    .withAstyanaxConfiguration(new AstyanaxConfigurationImpl()      
 	        .setDiscoveryType(NodeDiscoveryType.RING_DESCRIBE)
 	        .setConnectionPoolType(ConnectionPoolType.TOKEN_AWARE)
+		.setClock(new MicrosecondsAsyncClock())
 	    )
 	    .withConnectionPoolConfiguration(new ConnectionPoolConfigurationImpl("MyConnectionPool")
 	        .setMaxConnsPerHost(20)


### PR DESCRIPTION
Fix issue #103. This clock type is faster (no locking needed) and decreases possibility of conflict across nodes.
